### PR TITLE
fix bugs to support hol4 trindemossen1

### DIFF
--- a/compiler/RTLBlasterProofScript.sml
+++ b/compiler/RTLBlasterProofScript.sml
@@ -3254,7 +3254,7 @@ Definition same_state_outs_def:
  same_state_outs cenv cenv' ⇔ ∀var. sum_alookup cenv' var = sum_alookup cenv var
 End
 
-Theorem blast_out_correct:
+Theorem blast_out_correct_lemma:
  blast_out blast_s (var, out) = INR varout' ∧
  out_ok (var, out) ∧
  blast_reg_rel_fext fext blast_s.si s bs ∧
@@ -3287,7 +3287,7 @@ Theorem blast_out_correct:
 Proof
  Induct >- simp [blast_outs_def, sum_mapM_def, same_state_outs_def] \\
  PairCases \\ fs [blast_outs_def, sum_mapM_INR] \\ rpt strip_tac \\ rveq \\ simp [sum_mapM_INR] \\
- drule_strip blast_out_correct \\ drule_first \\ simp [same_state_outs_cons]
+ drule_strip blast_out_correct_lemma \\ drule_first \\ simp [same_state_outs_cons]
 QED
 
 (** Top level thm **)

--- a/compiler/RTLCompilerProofScript.sml
+++ b/compiler/RTLCompilerProofScript.sml
@@ -1055,17 +1055,6 @@ Theorem cell_input_idx_cell_input_covered_by_extenv:
  cell_input_idx inp idx = INR inp' /\ cell_input_covered_by_extenv EE inp ==>
  cell_input_covered_by_extenv EE inp'
 Proof
- Cases
- >- (Cases_on ‘v’ \\ fs [cell_input_idx_def, cell_input_covered_by_extenv_def])
- >- (rename1 ‘ExtInp _ idx’ \\ Cases_on ‘idx’ \\ fs [cell_input_idx_def, cell_input_covered_by_extenv_def])
- \\ rename1 ‘VarInp _ idx’ \\ Cases_on ‘idx’ \\ fs [cell_input_idx_def, cell_input_covered_by_extenv_def]
-QED
-
-Theorem cell_input_idx_cell_input_covered_by_extenv:
- !inp inp' idx EE.
- cell_input_idx inp idx = INR inp' /\ cell_input_covered_by_extenv EE inp ==>
- cell_input_covered_by_extenv EE inp'
-Proof
  rpt strip_tac \\ drule_strip cell_input_idx_INR \\ fs [cell_input_idx_def] \\ rveq \\
  fs [cell_input_covered_by_extenv_def]
 QED

--- a/compiler/compileLib.sml
+++ b/compiler/compileLib.sml
@@ -57,7 +57,7 @@ fun compile module_def = let
  val _ = timer |> Timer.checkRealTimer |> Time.toString |> (fn time => print ("DONE (" ^ time ^ ")\n"));
 
  val tech_nl_def = new_circuit_definition "tech_nl" tech_nl
- val tech_circuit_def = new_circuit_definition "tech_circuit" circuit'
+ (*val tech_circuit_def = new_circuit_definition "tech_circuit" circuit'*)
 
  (** LEC **)
  val _ = print "LECing..."

--- a/oracleScript.sml
+++ b/oracleScript.sml
@@ -92,7 +92,7 @@ Theorem oracle_bit_cong:
  init_seq_eq f g 1 /\ oracle_bit f = (b, f') /\ oracle_bit g = (b', g') ==>
  b' = b
 Proof
- rw [init_seq_eq_def, oracle_bit_def] \\ first_x_assum (qspec_then ‘0’ mp_tac) \\ simp []
+ rw [init_seq_eq_def, oracle_bit_def] \\ simp []
 QED
 
 Theorem oracle_bits_cong:

--- a/verilog/verilogSortScript.sml
+++ b/verilog/verilogSortScript.sml
@@ -280,7 +280,7 @@ Proof
  simp [lookup_thm, member_thm, comparisonTheory.string_cmp_good, finite_mapTheory.FLOOKUP_DEF]
 QED
 
-Theorem sort_by_deps_correct:
+Theorem sort_by_deps_correct_lemma:
  ∀ps ps'.
  sort_by_deps ps = INR ps' ⇒
  PERM ps ps' ∧
@@ -333,7 +333,7 @@ Theorem sort_by_deps_module_ok:
  ∀m combs. sort_by_deps m.combs = INR combs ∧ module_ok m ⇒ module_ok (m with combs := combs)
 Proof
  rw [module_ok_def, writes_ok_def, writes_overlap_ok_def] \\
- metis_tac [sort_by_deps_correct, PERM_vwrites, PERM_vnwrites]
+ metis_tac [sort_by_deps_correct_lemma, PERM_vwrites, PERM_vnwrites]
 QED
 
 (** Verilog semantics that sorts by deps **)
@@ -351,7 +351,7 @@ Theorem sort_by_deps_correct:
  sort_run fext fbits m n = run fext fbits (m with combs := combs) n ∧
  ∀var. MEM var (FLAT (MAP vwrites combs)) ⇔ MEM var (FLAT (MAP vwrites m.combs))
 Proof
- rw [sort_run_def, sum_bind_def] \\ metis_tac [sort_by_deps_correct, PERM_vwrites]
+ rw [sort_run_def, sum_bind_def] \\ metis_tac [sort_by_deps_correct_lemma, PERM_vwrites]
 QED
 
 Theorem already_sorted_sort_run:


### PR DESCRIPTION
Change-Id: I159093219895a1d624fc11d32a39ec7d11f9e8a6

Solved simple issues to support HOL4 trindemossen-1.
1. Rename some theorems with _lemma to aviod duplication.
2. Remove a duplicated theorem.
3. Simplify a proof.

There are still probelms for circuit compilation, for example, in examples/compilation/mixedCircuitCompile, using Holmake will produce an error:
error in quse /home/ningd/hardware-master/examples/compilation/mixedCircuitCompileScript.sml : HOL_ERR {message = "DUP \"mixed_v_tech_circuit_def\"", origin_function = "new_definition", origin_structure = "Definition"}

Such definitions are generated from compileLib, maybe Andreas can look at the details to solve it. It could work without using Holmake although.